### PR TITLE
Update recast

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "indent-string": "^2.1.0",
     "leveldown": "^1.6.0",
     "levelup": "^1.3.3",
-    "recast": "^0.11.22",
+    "recast": "^0.12.6",
     "resolve": "^1.3.1",
     "source-map": "^0.5.6"
   }


### PR DESCRIPTION
It looks like recast 0.11.x doesn't handle async/await:

```
Unable to transform source code for module /Users/smashwilson/src/atom/out/app/node_modules/github/lib/models/repository-states/present.js.

EAD';

    return this.git().checkoutFiles(paths, revision);
  }

  // Remote interactions

  async ==>fetch(branchName) {
    const remote = await this.getRemoteForBranch(branchName);
    if (!remote.is

Error: Line 303: Unexpected identifier
```

Because Atom and Electron ship with a libv8 that supports async/await natively, electron-link should be able to support it, too. Unless that messes with the snapshotting facility somehow?

Updating recast to 0.12 updates esprima to 4 which handles this properly.