### PR TITLE
Improve diagnostics on parse failures

### DIFF
--- a/src/generate-snapshot-script.js
+++ b/src/generate-snapshot-script.js
@@ -47,7 +47,17 @@ module.exports = async function (cache, options) {
         transformedSource = cachedTransform.source
         foundRequires = cachedTransform.requires
       } else {
-        transformedSource = indentString(transform.apply(), ' ', 2)
+        try {
+          transformedSource = indentString(transform.apply(), ' ', 2)
+        } catch (e) {
+          console.error(`Unable to transform source code for module ${filePath}.`)
+          if (e.index) {
+            const before = source.slice(e.index - 100, e.index)
+            const after = source.slice(e.index, e.index + 100)
+            console.error(`\n${before}==>${after}\n`)
+          }
+          throw e
+        }
         await cache.put({filePath, original: source, transformed: transformedSource, requires: foundRequires})
       }
 


### PR DESCRIPTION
Add some context around parse failures during snapshot generation, to make it a bit easier to narrow down the syntax that's causing a problem:

```
Unable to transform source code for module /Users/smashwilson/src/atom/out/app/node_modules/github/lib/models/repository-states/present.js.

EAD';

    return this.git().checkoutFiles(paths, revision);
  }

  // Remote interactions

  async ==>fetch(branchName) {
    const remote = await this.getRemoteForBranch(branchName);
    if (!remote.is

Error: Line 303: Unexpected identifier
  at ErrorHandler.constructError (/Users/smashwilson/src/electron-link/node_modules/esprima/dist/esprima.js:3396:22)
  at ErrorHandler.createError (/Users/smashwilson/src/electron-link/node_modules/esprima/dist/esprima.js:3414:27)
  at JSXParser.Parser.unexpectedTokenError (/Users/smashwilson/src/electron-link/node_modules/esprima/dist/esprima.js:542:39)
  at JSXParser.Parser.throwUnexpectedToken (/Users/smashwilson/src/electron-link/node_modules/esprima/dist/esprima.js:552:21)
```