### PR TITLE
Replace the globalFunctionNames loop in setGlobals with an assignment

### DIFF
--- a/src/blueprint.js
+++ b/src/blueprint.js
@@ -282,16 +282,7 @@ function generateSnapshot () {
     customRequire,
     setGlobals: function (newGlobal, newProcess, newWindow, newDocument, newConsole, nodeRequire) {
       // Populate the global function trampoline with the real global functions defined on newGlobal.
-      globalFunctionTrampoline = {};
-      for (const globalFunctionName of globalFunctionNames) {
-        if (newGlobal[globalFunctionName] === undefined) {
-          delete globalFunctionTrampoline[globalFunctionName]
-          delete outerScope[globalFunctionName]
-          continue
-        }
-        globalFunctionTrampoline[globalFunctionName] = newGlobal[globalFunctionName]
-        outerScope[globalFunctionName] = newGlobal[globalFunctionName]
-      }
+      globalFunctionTrampoline = newGlobal;
 
       for (let key of Object.keys(global)) {
         newGlobal[key] = global[key]


### PR DESCRIPTION
The loop over `globalFunctionNames` to populate `globalFunctionTrampoline` after the snapshot is loaded was taking ~60ms on macOS and ~350ms (!) on Windows. I'm still not entirely certain why, but we can replace this with a straight assignment without losing anything, which is nigh-immediate.