### PR TITLE
Transpile on demand

### DIFF
--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -225,7 +225,10 @@ module.exports = class FileRequireTransform {
 
   resolveModulePath (moduleName) {
     try {
-      const absolutePath = resolve.sync(moduleName, {basedir: path.dirname(this.options.filePath), extensions: ['.js', '.json']})
+      const absolutePath = resolve.sync(moduleName, {
+        basedir: path.dirname(this.options.filePath),
+        extensions: this.options.extensions || ['.js', '.json']
+      })
       const isCoreNodeModule = absolutePath.indexOf(path.sep) === -1
       return isCoreNodeModule ? null : absolutePath
     } catch (e) {

--- a/src/generate-snapshot-script.js
+++ b/src/generate-snapshot-script.js
@@ -43,6 +43,7 @@ module.exports = async function (cache, options) {
       const transform = new FileRequireTransform({
         filePath,
         source,
+        extensions: options.extensions,
         baseDirPath: options.baseDirPath,
         didFindRequire: (unresolvedPath, resolvedPath) => {
           if (options.shouldExcludeModule({requiringModulePath: filePath, requiredModulePath: resolvedPath})) {

--- a/src/generate-snapshot-script.js
+++ b/src/generate-snapshot-script.js
@@ -82,7 +82,6 @@ module.exports = async function (cache, options) {
 
       moduleASTs[relativeFilePath] = `function (exports, module, __filename, __dirname, require, define) {\n${transformedSource}\n}`
 
-      const resolvedRequirePaths = foundRequires.map(r => r.resolvedPath)
       for (let i = 0; i < foundRequires.length; i++) {
         const {resolvedPath} = foundRequires[i]
         requiredModulePaths.push(resolvedPath)

--- a/src/generate-snapshot-script.js
+++ b/src/generate-snapshot-script.js
@@ -12,7 +12,7 @@ module.exports = async function (cache, options) {
   // collecting abstract syntax trees for use in generating the script in
   // phase 2.
   const moduleASTs = {}
-  const requiredModulePaths = [options.mainPath]
+  const requiredModulePaths = options.mainPaths || [options.mainPath]
   const includedFilePaths = new Set(requiredModulePaths)
 
   if (!options.transpile) {

--- a/test/unit/generate-snapshot-script.test.js
+++ b/test/unit/generate-snapshot-script.test.js
@@ -12,6 +12,8 @@ suite('generateSnapshotScript({baseDirPath, mainPath})', () => {
 
   beforeEach(() => {
     previousRequire = Module.prototype.require
+
+    global.moduleInitialized = false
   })
 
   afterEach(() => {


### PR DESCRIPTION
Optionally provide a `transpile` function to the `electronLink()` call to arbitrarily modify module source on load, before require transformation.

##### Remaining work

- [x] Support `transpile` to modify source
- [x] Allow `extensions` to customize extensions used to locate modules to require
- [x] Optionally support multiple `mainPaths`
- [ ] Add new options to documentation