### PR TITLE
Use acorn for JS parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,11 @@
         "xtend": "~4.0.0"
       }
     },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -631,7 +636,8 @@
     "core-js": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -882,9 +888,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esutils": {
       "version": "2.0.2",
@@ -3300,21 +3306,20 @@
       }
     },
     "recast": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-      "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.5.tgz",
+      "integrity": "sha512-K+DgfAMIyEjNKjaFSWgg9TTu7wFgU/4KTyw4E9vl6M5QPDuUYbyt49Yzb0EIDbZks+6lXk/UZ9eTuE4jlLyf2A==",
       "requires": {
-        "ast-types": "0.10.1",
-        "core-js": "^2.4.1",
+        "ast-types": "0.12.3",
         "esprima": "~4.0.0",
-        "private": "~0.1.5",
+        "private": "^0.1.8",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "ast-types": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-          "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
+          "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA=="
         },
         "source-map": {
           "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
+    "acorn": "^6.1.1",
     "ast-util": "^0.6.0",
+    "encoding-down": "~5.0.0",
     "indent-string": "^3.2.0",
     "leveldown": "~4.0.0",
     "levelup": "~3.0.0",
-    "encoding-down": "~5.0.0",
-    "recast": "^0.12.6",
+    "recast": "^0.17.5",
     "resolve": "^1.5.0",
     "source-map": "^0.5.6"
   }

--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -29,7 +29,8 @@ module.exports = class FileRequireTransform {
       parser: {
         parse(source) {
           return require('recast/parsers/acorn').parse(source, {
-            ecmaVersion: 9
+            ecmaVersion: 9,
+            sourceType: 'script'
           })
         }
       }

--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -25,7 +25,15 @@ module.exports = class FileRequireTransform {
       // supported inside javascript strings) with escape unicode sequences.
       source = "module.exports = " + source.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029')
     }
-    this.ast = recast.parse(source)
+    this.ast = recast.parse(source, {
+      parser: {
+        parse(source) {
+          return require('recast/parsers/acorn').parse(source, {
+            ecmaVersion: 9
+          })
+        }
+      }
+    })
     this.lazyRequireFunctionsByVariableName = new Map()
     this.replaceDeferredRequiresWithLazyFunctions()
     this.replaceReferencesToDeferredRequiresWithFunctionCalls()

--- a/test/unit/file-require-transform.test.js
+++ b/test/unit/file-require-transform.test.js
@@ -355,7 +355,7 @@ suite('FileRequireTransform', () => {
     )
   })
 
-  test('Modern JS syntax features', () => {
+  test('Object spread properties', () => {
     const source = 'let {a, b, ...rest} = {a: 1, b: 2, c: 3}'
     assert.equal(
       new FileRequireTransform({source, didFindRequire: () => false}).apply(),

--- a/test/unit/file-require-transform.test.js
+++ b/test/unit/file-require-transform.test.js
@@ -355,6 +355,16 @@ suite('FileRequireTransform', () => {
     )
   })
 
+  test('Modern JS syntax features', () => {
+    const source = 'let {a, b, ...rest} = {a: 1, b: 2, c: 3}'
+    assert.equal(
+      new FileRequireTransform({source, didFindRequire: () => false}).apply(),
+      dedent`
+        let {a, b, ...rest} = {a: 1, b: 2, c: 3}
+      `
+    )
+  })
+
   test('path resolution', () => {
     const baseDirPath = path.resolve(__dirname, '..', 'fixtures', 'module-1')
     const filePath = path.join(baseDirPath, 'dir', 'entry.js')


### PR DESCRIPTION
When trying to land an upgrade of the `markdown-preview` package, we realized that `electron-link` does not support some modern JS syntax features. This was due to the `esprima` parser which is quite old.

To solve this, I've changed the `esprima` configuration to use `acorn` as a parser, specifying that we want to support the [9th edition syntax features](https://www.ecma-international.org/ecma-262/9.0/index.html).

## Verification process

- [x] Add unit test with new syntax feature.
- [x] Patch the `electron-link` version used in https://github.com/atom/atom/pull/19209 and check that the build passes
