### PR TITLE
Lazy require fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha test/**/*.test.js --ui=tdd --require @babel/register",
     "tdd": "electron-mocha test/**/*.test.js --ui=tdd --renderer --interactive --require @babel/register",
-    "prepublish": "rimraf lib && babel src -d lib"
+    "build": "rimraf lib && babel src -d lib",
+    "prepare": "npm run build"
   },
   "author": "",
   "license": "MIT",

--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -137,6 +137,8 @@ module.exports = class FileRequireTransform {
         assert.equal(assignmentLhs.type, 'Identifier')
 
         if (["module", "exports"].includes(assignmentLhs.name)) {
+          console.warn(`${this.options.filePath}\n` +
+          `The reference to the module is replaced with the lazy function, but it is assigned to "module" or "exports". In some cases the bundle might not work, which you should fix manually.`);
           return // don't replace anything (module.exports = get_name)
         }
 
@@ -218,6 +220,8 @@ module.exports = class FileRequireTransform {
       }
       parentPath = parentPath.parent
     }
+    console.warn(`${this.options.filePath}\n` +
+    `The reference to the module is replaced with the lazy function, but it was not in an assignment expression or a variable declaration. In some cases the bundle might not work, which you should fix manually.`);
     return    // just call the reference it directly
   }
 

--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -212,11 +212,7 @@ module.exports = class FileRequireTransform {
       }
       parentPath = parentPath.parent
     }
-
-    throw new Error(
-      `${this.options.filePath}\n` +
-      `Cannot replace with lazy function because the supplied node does not belong to an assignment expression or a variable declaration!`
-    )
+    return    // just call the reference it directly
   }
 
   isReferenceToLazyRequire (astPath) {

--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -129,12 +129,18 @@ module.exports = class FileRequireTransform {
           ifStatementPath = ifStatementPath.parent
         }
 
-        // Ensure we're assigning to a variable declared in this scope.
+
         let assignmentLhs = parentNode.left
         while (assignmentLhs.type === 'MemberExpression') {
           assignmentLhs = assignmentLhs.object
         }
         assert.equal(assignmentLhs.type, 'Identifier')
+
+        if (["module", "exports"].includes(assignmentLhs.name)) {
+          return // don't replace anything (module.exports = get_name)
+        }
+
+        // Ensure we're assigning to a variable declared in this scope.
         assert(
           astPath.scope.declares(assignmentLhs.name),
           `${this.options.filePath}\nAssigning a deferred module to a variable that was not declared in this scope is not supported!`
@@ -218,14 +224,17 @@ module.exports = class FileRequireTransform {
   isReferenceToLazyRequire (astPath) {
     const scope = astPath.scope
     const lazyRequireFunctionName = this.lazyRequireFunctionsByVariableName.get(astPath.node.name)
-    return (
-      lazyRequireFunctionName != null &&
-      (scope.node.type !== 'FunctionDeclaration' || lazyRequireFunctionName !== astPath.scope.node.id.name) &&
-      (scope.node.type !== 'FunctionExpression' || scope.path.parent.node.type !== 'AssignmentExpression' || lazyRequireFunctionName !== scope.path.parent.node.left.name) &&
-      (astPath.parent.node.type !== 'Property' || astPath.parent.parent.node.type !== 'ObjectPattern') &&
-      astPath.parent.node.type !== 'AssignmentExpression' &&
-      astUtil.isReference(astPath)
-    )
+    if (lazyRequireFunctionName != null &&
+        (scope.node.type !== 'FunctionDeclaration' || lazyRequireFunctionName !== astPath.scope.node.id.name) &&
+        (scope.node.type !== 'FunctionExpression' || scope.path.parent.node.type !== 'AssignmentExpression' || lazyRequireFunctionName !== scope.path.parent.node.left.name) &&
+        (astPath.parent.node.type !== 'Property' || astPath.parent.parent.node.type !== 'ObjectPattern') ) {
+      if (astPath.parent.node.type === 'AssignmentExpression') {
+        return astPath.name === "right" && astUtil.isReference(astPath) // e.g module.exports = a_reference;
+      } else {
+        return astUtil.isReference(astPath)
+      }
+
+    }
   }
 
   resolveModulePath (moduleName) {

--- a/src/file-require-transform.js
+++ b/src/file-require-transform.js
@@ -137,7 +137,7 @@ module.exports = class FileRequireTransform {
         assert.equal(assignmentLhs.type, 'Identifier')
 
         if (["module", "exports"].includes(assignmentLhs.name)) {
-          console.warn(`${this.options.filePath}\n` +
+          console.warn(`##[warning] ${this.options.filePath}\n` +
           `The reference to the module is replaced with the lazy function, but it is assigned to "module" or "exports". In some cases the bundle might not work, which you should fix manually.`);
           return // don't replace anything (module.exports = get_name)
         }
@@ -220,7 +220,7 @@ module.exports = class FileRequireTransform {
       }
       parentPath = parentPath.parent
     }
-    console.warn(`${this.options.filePath}\n` +
+    console.warn(`##[warning] ${this.options.filePath}\n` +
     `The reference to the module is replaced with the lazy function, but it was not in an assignment expression or a variable declaration. In some cases the bundle might not work, which you should fix manually.`);
     return    // just call the reference it directly
   }

--- a/test/unit/file-require-transform.test.js
+++ b/test/unit/file-require-transform.test.js
@@ -123,21 +123,6 @@ suite('FileRequireTransform', () => {
     `)
   })
 
-  test('top-level usage of deferred modules', () => {
-    assert.throws(() => {
-      new FileRequireTransform({source: `var a = require('a'); a()`, didFindRequire: (mod) => true}).apply()
-    })
-    assert.throws(() => {
-      new FileRequireTransform({source: `require('a')()`, didFindRequire: (mod) => true}).apply()
-    })
-    assert.throws(() => {
-      new FileRequireTransform({source: `foo = require('a')`, didFindRequire: (mod) => true}).apply()
-    })
-    assert.throws(() => {
-      new FileRequireTransform({source: `module.exports.a = require('a')`, didFindRequire: (mod) => true}).apply()
-    })
-  })
-
   test('requires that appear in a closure wrapper defined in the top-level scope (e.g. CoffeeScript)', () => {
     const source = dedent`
       (function () {

--- a/test/unit/file-require-transform.test.js
+++ b/test/unit/file-require-transform.test.js
@@ -467,4 +467,34 @@ suite('FileRequireTransform', () => {
       `
     )
   })
+  test('assign to `module` or `exports`', () => {
+    const source = dedent`
+      var pack = require('pack')      
+      if (condition) {
+          module.exports.pack = pack
+          module.exports = pack
+          exports.pack = pack
+          exports = pack
+      }
+    `
+    assert.equal(
+        new FileRequireTransform({source, didFindRequire: (mod) => mod === 'pack'}).apply(),
+        dedent`
+        var pack
+        
+        function get_pack() {
+            return pack = pack || require('pack');
+        }
+        
+        if (condition) {
+            module.exports.pack = get_pack()
+            module.exports = get_pack()
+            exports.pack = get_pack()
+            exports = get_pack()
+        }
+      `
+    )
+  })
+
+
 })


### PR DESCRIPTION
This fixes #2! 😃 

Two reasons that #2 error happened are fixed:
- assigning lazy require to module or exports.
- just using the reference directly.

Now we handle those situations instead of throwing error.

cc: @lkashef @smashwilson 

This will solve the issue in https://github.com/atom/atom/pull/20965